### PR TITLE
Add connection: local to local ini file check

### DIFF
--- a/tasks/custom-ini.yml
+++ b/tasks/custom-ini.yml
@@ -1,4 +1,5 @@
 - name: PHP | Check for custom INI files
+  connection: local
   local_action: stat path="{{ files_dir }}/php"
   become: no
   register: ini_files


### PR DESCRIPTION
This prevents ansible trying to make an ssh connection to localhost if localhost is configured as part of the inventory.